### PR TITLE
Midi toggle

### DIFF
--- a/source/control-button-board.c
+++ b/source/control-button-board.c
@@ -173,7 +173,7 @@ static void run(LV2_Handle instance, uint32_t n_samples) {
 			}
 
 			// Update the LED status based on the new state
-							lv2_log_trace(&plugin->logger, "trigger LED change <%i> - 0 with <%u>\n", i, new_state);
+			lv2_log_trace(&plugin->logger, "trigger LED change <%i> - 0 with <%u>\n", i, new_state);
 			trigger_led_change(plugin, i, 0, new_state);
 			lv2_log_trace(&plugin->logger, "trigger LED change <%i> - 1 with <%u>\n", i, new_state);
 			trigger_led_change(plugin, i, 1, new_state);

--- a/source/control-button-board.c
+++ b/source/control-button-board.c
@@ -37,7 +37,7 @@
 #define NUM_PAIRS 5
 
 // Define the total number of ports
-#define TOTAL_PORTS (NUM_PAIRS * 3+1)
+#define TOTAL_PORTS (NUM_PAIRS * 3+2)
 
 // The main plugin struct to hold the toggle statuses and other state data
 typedef struct {
@@ -45,6 +45,7 @@ typedef struct {
 	const float* toggles[NUM_PAIRS][2];
 	float* cv_output[NUM_PAIRS];
 	const LV2_Atom_Sequence* midi_in_port;
+	const float* midi_CC;
 	// Features
 	LV2_URID_Map*  map;
 	LV2_HMI_WidgetControl* hmi;
@@ -93,15 +94,31 @@ static void connect_port(LV2_Handle instance,
 						 uint32_t port,
 						 void* data_location) {
 	TogglePlugin* plugin = (TogglePlugin*)instance;
+
 	if (port < 2*NUM_PAIRS) {
 		uint8_t pair_index = port / 2;
 		uint8_t toggle_index = port % 2;
 		plugin->toggles[pair_index][toggle_index] = (const float*)data_location;
-	} else if (port < TOTAL_PORTS-1) {
+
+	} else if (port < 3*NUM_PAIRS) {
 		uint8_t pair_index = port - 2*NUM_PAIRS;
 		plugin->cv_output[pair_index] = (float*)data_location;
-	} else if (port == TOTAL_PORTS-1) {
-		plugin->midi_in_port = (const LV2_Atom_Sequence*)data_location;
+	} else {
+		int n = port-3*NUM_PAIRS;
+		switch (n)
+		{
+		case 0: //midi input port
+			plugin->midi_in_port = (const LV2_Atom_Sequence*)data_location;
+
+			break;
+		case 1: //midi CC
+			plugin->midi_CC = (const float*)data_location;
+			break;
+		
+		default:
+
+			break;
+		}
 	}
 }
 
@@ -120,29 +137,29 @@ void trigger_led_change(TogglePlugin* plugin, uint8_t pair_index, uint8_t toggle
 static void run(LV2_Handle instance, uint32_t n_samples) {
 	TogglePlugin* plugin = (TogglePlugin*)instance;
 	uint8_t midi_toggles[NUM_PAIRS];
-
-
+	
 	memset(midi_toggles,0,NUM_PAIRS*sizeof(uint8_t));
 
 	// Read incoming events
 	LV2_ATOM_SEQUENCE_FOREACH (plugin->midi_in_port, ev) {
 		const uint8_t* const msg = (const uint8_t*)(ev + 1);
 		switch (lv2_midi_message_type(msg)) {
-		case LV2_MIDI_MSG_CONTROLLER:
-			if( msg[1] == 0x13) {
-				if (msg[2] < NUM_PAIRS ) {
-					midi_toggles[msg[2]] = 1;
+			case LV2_MIDI_MSG_CONTROLLER:
+				if 	( msg[1] == (uint8_t)(*(plugin->midi_CC))) {
+					if (msg[2] < NUM_PAIRS ) {
+						midi_toggles[msg[2]] = 1;
+					}			
 				}
-			
-			}
-			
-      default:
-        // Forward all other MIDI events directly
-        // lv2_atom_sequence_append_event(self->out_port, out_capacity, ev);
-		#warning TODO: add output port
-        break;
-      }
+				break;	
+
+			default:
+				// Forward all other MIDI events directly
+				// lv2_atom_sequence_append_event(self->out_port, out_capacity, ev);
+#warning TODO: add output port
+				break;
+		}
 	}
+
 	for (int i = 0; i < NUM_PAIRS; i++) {
 		// Check the toggle states
 		uint8_t toggle1on = (*(plugin->toggles[i][0]) > 0.0f) ? 1 : 0;
@@ -162,7 +179,6 @@ static void run(LV2_Handle instance, uint32_t n_samples) {
 		if ( (new_state != toggle1on) || (new_state != toggle2on) || (midi_toggles[i]) )
 			new_state = (new_state ? 0 : 1);
 #endif	
-
 
 		if(new_state != plugin->states[i]) {
 			// Set the CV output to 10V if the state is on, 0V if off
@@ -206,6 +222,7 @@ static void run(LV2_Handle instance, uint32_t n_samples) {
 			plugin->states[i] = new_state;
 		}
 	}
+
 }
 
 

--- a/source/control-button-board.c
+++ b/source/control-button-board.c
@@ -15,13 +15,21 @@
  * along with this LV2 plugin; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
-#include <lv2/core/lv2.h>
+
+#include <stdio.h>
 #include <stdlib.h>
 #include "lv2-hmi.h"
-#include "lv2/core/lv2_util.h"
 #include "control-input-port-change-request.h"  // Include the extension header
-#include "lv2/log/log.h"
-#include "lv2/log/logger.h"
+#include <lv2/core/lv2.h>
+#include <lv2/core/lv2_util.h>
+#include <lv2/atom/atom.h>
+#include <lv2/atom/util.h>
+#include <lv2/log/log.h>
+#include <lv2/log/logger.h>
+#include <lv2/midi/midi.h>
+#include <lv2/urid/urid.h>
+
+
 
 #define PLUGIN_URI "http://example.org/control-button-board"
 
@@ -29,14 +37,14 @@
 #define NUM_PAIRS 5
 
 // Define the total number of ports
-#define TOTAL_PORTS (NUM_PAIRS * 3)
+#define TOTAL_PORTS (NUM_PAIRS * 3+1)
 
 // The main plugin struct to hold the toggle statuses and other state data
 typedef struct {
 	// Ports
 	const float* toggles[NUM_PAIRS][2];
 	float* cv_output[NUM_PAIRS];
-
+	const LV2_Atom_Sequence* midi_in_port;
 	// Features
 	LV2_URID_Map*  map;
 	LV2_HMI_WidgetControl* hmi;
@@ -89,9 +97,11 @@ static void connect_port(LV2_Handle instance,
 		uint8_t pair_index = port / 2;
 		uint8_t toggle_index = port % 2;
 		plugin->toggles[pair_index][toggle_index] = (const float*)data_location;
-	} else if (port < TOTAL_PORTS) {
+	} else if (port < TOTAL_PORTS-1) {
 		uint8_t pair_index = port - 2*NUM_PAIRS;
 		plugin->cv_output[pair_index] = (float*)data_location;
+	} else if (port == TOTAL_PORTS-1) {
+		plugin->midi_in_port = (const LV2_Atom_Sequence*)data_location;
 	}
 }
 
@@ -109,14 +119,37 @@ void trigger_led_change(TogglePlugin* plugin, uint8_t pair_index, uint8_t toggle
 // Main processing function
 static void run(LV2_Handle instance, uint32_t n_samples) {
 	TogglePlugin* plugin = (TogglePlugin*)instance;
+	uint8_t midi_toggles[NUM_PAIRS];
 
+
+	memset(midi_toggles,0,NUM_PAIRS*sizeof(uint8_t));
+
+	// Read incoming events
+	LV2_ATOM_SEQUENCE_FOREACH (plugin->midi_in_port, ev) {
+		const uint8_t* const msg = (const uint8_t*)(ev + 1);
+		switch (lv2_midi_message_type(msg)) {
+		case LV2_MIDI_MSG_CONTROLLER:
+			if( msg[1] == 0x13) {
+				if (msg[2] < NUM_PAIRS ) {
+					midi_toggles[msg[2]] = 1;
+				}
+			
+			}
+			
+      default:
+        // Forward all other MIDI events directly
+        // lv2_atom_sequence_append_event(self->out_port, out_capacity, ev);
+		#warning TODO: add output port
+        break;
+      }
+	}
 	for (int i = 0; i < NUM_PAIRS; i++) {
 		// Check the toggle states
 		uint8_t toggle1on = (*(plugin->toggles[i][0]) > 0.0f) ? 1 : 0;
 		uint8_t toggle2on = (*(plugin->toggles[i][1]) > 0.0f) ? 1 : 0;
 
 		uint8_t new_state = plugin->states[i];
-
+#if 0
 		// If the state has changed, update the state, CV output, and request the other toggle to change
 		if (plugin->states[i] != toggle1on) {
 			// this means something has happened with toggle1
@@ -125,6 +158,11 @@ static void run(LV2_Handle instance, uint32_t n_samples) {
 			// this means something has happened with toggle1
 			new_state = toggle2on;
 		} 
+#else
+		if ( (new_state != toggle1on) || (new_state != toggle2on) || (midi_toggles[i]) )
+			new_state = (new_state ? 0 : 1);
+#endif	
+
 
 		if(new_state != plugin->states[i]) {
 			// Set the CV output to 10V if the state is on, 0V if off
@@ -135,7 +173,7 @@ static void run(LV2_Handle instance, uint32_t n_samples) {
 			}
 
 			// Update the LED status based on the new state
-			lv2_log_trace(&plugin->logger, "trigger LED change <%i> - 0 with <%u>\n", i, new_state);
+							lv2_log_trace(&plugin->logger, "trigger LED change <%i> - 0 with <%u>\n", i, new_state);
 			trigger_led_change(plugin, i, 0, new_state);
 			lv2_log_trace(&plugin->logger, "trigger LED change <%i> - 1 with <%u>\n", i, new_state);
 			trigger_led_change(plugin, i, 1, new_state);

--- a/source/control-button-board.lv2/control-button-board.ttl
+++ b/source/control-button-board.lv2/control-button-board.ttl
@@ -6,6 +6,11 @@
 @prefix modgui: <http://moddevices.com/ns/modgui#>.
 @prefix doap: <http://usefulinc.com/ns/doap#>.
 @prefix foaf: <http://xmlns.com/foaf/0.1/>.
+@prefix atom: <http://lv2plug.in/ns/ext/atom#> .
+@prefix midi: <http://lv2plug.in/ns/ext/midi#>.
+@prefix urid: <http://lv2plug.in/ns/ext/urid#>.      
+@prefix epp:  <http://lv2plug.in/ns/ext/port-props#> .
+
 
 <http://example.org/control-button-board>
     a lv2:Plugin , mod:ControlVoltagePlugin;
@@ -25,7 +30,7 @@
         foaf:mbox <mailto:njsiva@gmail.com>;
     ];
     lv2:minorVersion 1;
-    lv2:microVersion 0;
+    lv2:microVersion 1;
     lv2:optionalFeature lv2:hardRTCapable, <http://moddevices.com/ns/hmi#WidgetControl>;
     lv2:extensionData <http://moddevices.com/ns/hmi#PluginNotification>;
     rdfs:label "Control Button Board" ;
@@ -129,13 +134,22 @@ through the CV control.
         lv2:name "Cv Press Output 4";
 		lv2:minimum 0.0 ;
 		lv2:maximum 10.0 ;
-    ],[
+    ], [
         a lv2:OutputPort, lv2:CVPort, mod:CVPort;
         lv2:index 14;
         lv2:symbol "cvout5";
         lv2:name "Cv Press Output 5";
 		lv2:minimum 0.0 ;
 		lv2:maximum 10.0 ;
+    ], [
+        a lv2:InputPort ,
+            atom:AtomPort ;
+        atom:bufferType atom:Sequence ;
+        atom:supports midi:MidiEvent ;
+        lv2:designation lv2:control ;
+        lv2:index 15 ;
+        lv2:symbol "midi_control" ;
+        lv2:name "midi_control";
     ];
 	modgui:gui [
 		modgui:brand "J Siva";

--- a/source/control-button-board.lv2/control-button-board.ttl
+++ b/source/control-button-board.lv2/control-button-board.ttl
@@ -35,15 +35,20 @@
     lv2:extensionData <http://moddevices.com/ns/hmi#PluginNotification>;
     rdfs:label "Control Button Board" ;
     rdfs:comment """
-A plugin that five pairs of toggle buttons that operate in unison within each
+A plugin providing five pairs of toggle buttons that operate in unison within each
 pair - if one of the toggles is turned on, the other turn on automaticall and a HIGH CV
 signal is sent through the corresponding CV port. If either is then turned off, then
 both toggles within the pair are turned off automatically and a LOW CV signal is sent, 
 If a mod hardware button capable of colour LEDs is associated with one or both buttons, 
-colouration should match CV status. This plugin can be used with MIDI
-controllers, for instance, to pair up each latching switch on the controller
-with a hardware button that act act similarly to control an effect on-off button
-through the CV control.
+colouration should match CV status. 
+
+This plugin can be used with MIDI controllers:  for instance, to pair up each latching 
+switch on the controller with a hardware button that act act similarly to control an 
+effect on-off button through the CV control. Moreover it is possible to commute a switch
+pair trough a dedicated midi CC (selectable) having as a Control Value the index of the 
+switch pair (0 to 4). E.g. sentting the CC parameter to 19 and sending a CC 19 with data 1
+toggles the second pair (it counts from 0). This could help toggling a plugin via midi 
+without having to sync ots initial state between the MOD unit and the controller. 
     """;
 
     lv2:port [
@@ -70,7 +75,7 @@ through the CV control.
         lv2:portProperty lv2:integer, lv2:toggled;
         lv2:symbol "toggle22" ;
         lv2:name "Toggle 2-B" ;
-    ],[
+    ], [
         a lv2:ControlPort, lv2:InputPort ;
         lv2:index 4 ;
         lv2:portProperty lv2:integer, lv2:toggled;
@@ -82,7 +87,7 @@ through the CV control.
         lv2:portProperty lv2:integer, lv2:toggled;
         lv2:symbol "toggle32" ;
         lv2:name "Toggle 3-B" ;
-    ],[
+    ], [
         a lv2:ControlPort, lv2:InputPort ;
         lv2:index 6 ;
         lv2:portProperty lv2:integer, lv2:toggled;
@@ -94,7 +99,7 @@ through the CV control.
         lv2:portProperty lv2:integer, lv2:toggled;
         lv2:symbol "toggle42" ;
         lv2:name "Toggle 4-B" ;
-    ],[
+    ], [
         a lv2:ControlPort, lv2:InputPort ;
         lv2:index 8 ;
         lv2:portProperty lv2:integer, lv2:toggled;
@@ -150,6 +155,16 @@ through the CV control.
         lv2:index 15 ;
         lv2:symbol "midi_control" ;
         lv2:name "midi_control";
+    ], [    
+        a lv2:InputPort, lv2:ControlPort;
+        lv2:index 16;
+        lv2:symbol "CC";
+        lv2:name "CC";
+        lv2:minimum 0;
+        lv2:default 0;
+        lv2:maximum 127;
+        lv2:portProperty lv2:integer;
+
     ];
 	modgui:gui [
 		modgui:brand "J Siva";

--- a/source/control-button-board.lv2/modgui/icon-control-button-board.html
+++ b/source/control-button-board.lv2/modgui/icon-control-button-board.html
@@ -33,5 +33,9 @@
         </div>
         {{/effect.ports.cv.output}}
     </div>
+    <div class="mod-pedal-input">
+        <div class="mod-input" title="Midi Input 1" mod-role="input-midi-port" mod-port-symbol="midi_control"></div>
+    </div>
+    
 </div>
 


### PR DESCRIPTION
Added the possibility to toggle a switch pair trough a midi CC in a different way. 

Normally, when a toggle is paired to a CC in the common way, it goes to ON receiving a value >=64, and to OFF otherwise. 

This requires that the external controller is able to know the current state of the toggle. There are cases (e.g. loading a snapshot) where this cannot be easily accomplished. 

In my implementation, a midi-in port has been added to directly receive CC without the pairing mechanism.  Also, a new parameter (CC) has been added to select the midi_CC to listen for. 

When such CC is received, the "value" field is used as the index of the switch pair to be toggled.

E.g. if the CC parameter is set to 19, a midi CC message (control=19, value=0) toggle the first pair. A midi message (control=19, value=1) toggle the second pair and so on, up to the number of available pairs.

Summing it up: 
Normal MOD approach to pair a toggle to a midi CC  ( control, value) is indexing the switch with the control field and setting it to  "value". There is a "control" for each toggle
My addition allows to use a single CC "control" and addressing the toggles via the "value", to change their current state.

Edit: fixed example (control =19, value = 1) to toggle the second pair